### PR TITLE
Add schedule runs and on-demand runs to workflows

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: # For on demand runs
+  schedule:
+    - cron: 0 0 * * * # Scheduled run every day at midnight
 jobs:
   build:
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: # For on demand runs
+  schedule:
+    - cron: 0 0 * * * # Scheduled run every day at midnight
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
In our ongoing efforts to maintain the highest quality in our codebase, this PR introduces two significant enhancements to our

Scheduled Runs: Our pipelines will now run daily at midnight. This will keep our pipelines fresh and ensure that any external changes, such as updates to our dependencies, don't cause bugs.

On-Demand Runs: Developers can manually trigger the CI/CD process via the GitHub Actions tab if they need immediate verification of the CI/CD pipeline works without pushing a commit or waiting for a daily che